### PR TITLE
AppRun: Set QT_QPA_PLATFORM at start of script

### DIFF
--- a/AppRun
+++ b/AppRun
@@ -1,5 +1,10 @@
 #!/bin/sh -e
 
+# Force xcb platform for Qt applications
+if [ -z "${QT_QPA_PLATFORM}" ]; then
+    export QT_QPA_PLATFORM=xcb
+fi
+
 # add your command to execute here
 exec=
 


### PR DESCRIPTION
Forces yuzu to use X11 even on Wayland hosts.