### PR TITLE
Preserve working directory when launching AppImage

### DIFF
--- a/AppRun.sh
+++ b/AppRun.sh
@@ -2,42 +2,38 @@
 
 # A shell script that does the same as the binaries in the release section.
 
-cd "$(dirname "$0")"
-
 cxxpre=""
 gccpre=""
 execpre=""
 libc6arch="libc6,x86-64"
-exec="./bin/$(sed -n -e 's|%f||' -e 's|^Exec=||p' $(ls -1 *.desktop))"
+exec="$APPDIR/usr/bin/$(sed -n -e 's|%f||' -e 's|^Exec=||p' $(ls -1 $APPDIR/*.desktop))"
 
 if [ -n "$APPIMAGE" ] && [ "$(file -b "$APPIMAGE" | cut -d, -f2)" != " x86-64" ]; then
   libc6arch="libc6"
 fi
 
-cd "usr"
-
-if [ -e "./optional/libstdc++/libstdc++.so.6" ]; then
+if [ -e "$APPDIR/usr/optional/libstdc++/libstdc++.so.6" ]; then
   lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libstdc++\.so\.6 ($libc6arch)" | awk 'NR==1{print $NF}')"
   sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GLIBCXX_3\.4' | sort -V | tail -n1)
-  sym_app=$(tr '\0' '\n' < "./optional/libstdc++/libstdc++.so.6" | grep -e '^GLIBCXX_3\.4' | sort -V | tail -n1)
+  sym_app=$(tr '\0' '\n' < "$APPDIR/usr/optional/libstdc++/libstdc++.so.6" | grep -e '^GLIBCXX_3\.4' | sort -V | tail -n1)
   if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
-    cxxpath="./optional/libstdc++:"
+    cxxpath="$APPDIR/usr/optional/libstdc++:"
   fi
 fi
 
-if [ -e "./optional/libgcc/libgcc_s.so.1" ]; then
+if [ -e "$APPDIR/usr/optional/libgcc/libgcc_s.so.1" ]; then
   lib="$(PATH="/sbin:$PATH" ldconfig -p | grep "libgcc_s\.so\.1 ($libc6arch)" | awk 'NR==1{print $NF}')"
   sym_sys=$(tr '\0' '\n' < "$lib" | grep -e '^GCC_[0-9]\\.[0-9]' | sort -V | tail -n1)
-  sym_app=$(tr '\0' '\n' < "./optional/libgcc/libgcc_s.so.1" | grep -e '^GCC_[0-9]\\.[0-9]' | sort -V | tail -n1)
+  sym_app=$(tr '\0' '\n' < "$APPDIR/usr/optional/libgcc/libgcc_s.so.1" | grep -e '^GCC_[0-9]\\.[0-9]' | sort -V | tail -n1)
   if [ "$(printf "${sym_sys}\n${sym_app}"| sort -V | tail -1)" != "$sym_sys" ]; then
-    gccpath="./optional/libgcc:"
+    gccpath="$APPDIR/usr/optional/libgcc:"
   fi
 fi
 
 if [ -n "$cxxpath" ] || [ -n "$gccpath" ]; then
-  if [ -e "./optional/exec.so" ]; then
+  if [ -e "$APPDIR/usr/optional/exec.so" ]; then
     execpre=""
-    export LD_PRELOAD="./optional/exec.so:${LD_PRELOAD}"
+    export LD_PRELOAD="$APPDIR/usr/optional/exec.so:${LD_PRELOAD}"
   fi
   export LD_LIBRARY_PATH="${cxxpath}${gccpath}${LD_LIBRARY_PATH}"
 fi


### PR DESCRIPTION
Makes it possible to pass a relative path to the AppImage.

For AppRun.sh all paths inside the AppImage have been switched to use $APPDIR

----
Semi related: yuzu seems to SEGFAULT if asked to launch a file that doesn't exist. Noting here in case I forget to mention it elsewhere.